### PR TITLE
Returning the current connection

### DIFF
--- a/src/codeception/multidb/MultiDb.php
+++ b/src/codeception/multidb/MultiDb.php
@@ -101,7 +101,7 @@ class MultiDb extends CodeceptionModule implements DbInterface
     public $connections = [];
 
     /**
-     * @var \PDO
+     * @var string
      */
     protected $currentConnection;
 

--- a/src/codeception/multidb/MultiDb.php
+++ b/src/codeception/multidb/MultiDb.php
@@ -659,4 +659,12 @@ class MultiDb extends CodeceptionModule implements DbInterface
     {
         $this->loadDump($connection);
     }
+
+    /**
+     * @return Driver
+     */
+    public function getCurrentDriver()
+    {
+        return $this->currentDriver;
+    }
 }


### PR DESCRIPTION
Adding a method returning the current connection, it can be helpful for other modules depending on the database.